### PR TITLE
Add configuration and profiles

### DIFF
--- a/cpupower_gui/__init__.py
+++ b/cpupower_gui/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["utils", "config"]
+

--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -27,6 +27,7 @@ class CpuPowerConfig:
     def __init__(self):
         self.config = ConfigParser()
         self.config.add_section("Profile")
+        self.config.add_section("GUI")
         self.config.set("Profile", "profile", "Balanced")
         self._profiles = {}
         # Initialise class
@@ -86,7 +87,7 @@ class CpuPowerConfig:
         return self._profiles.get(name)
 
     def get_profile_settings(self, name):
-        """Return profile settings
+        """Returns profile settings
 
         Args:
             name: Name of the profile
@@ -98,6 +99,15 @@ class CpuPowerConfig:
         if name in self._profiles:
             return self._profiles[name].settings
         return None
+
+    def get_gui_settings(self):
+        """Returns GUI settings
+
+        Returns:
+            settings: GUI settings
+
+        """
+        return self.config["GUI"]
 
     def _generate_default_profiles(self):
         """Generate default profiles based on current hardware.
@@ -281,4 +291,3 @@ def parse_online(cpu: int, online: str):
         return True
 
     return False
-

--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -6,7 +6,12 @@ from shlex import split
 
 from xdg import BaseDirectory
 
-from cpupower_gui.utils import read_govs, read_freq_lims, cpus_available, parse_core_list
+from cpupower_gui.utils import (
+    read_govs,
+    read_freq_lims,
+    cpus_available,
+    parse_core_list,
+)
 
 
 XDG_PATH = Path(BaseDirectory.save_config_path("cpupower_gui"))
@@ -118,6 +123,7 @@ class CpuPowerConfig:
 
 class Profile:
     """Wrapper for .profile files"""
+
     def __init__(self, filename=None):
         self.settings = {}
         self.name = ""
@@ -275,3 +281,4 @@ def parse_online(cpu: int, online: str):
         return True
 
     return False
+

--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -1,0 +1,277 @@
+"""Class for reading configuration files"""
+
+from configparser import ConfigParser
+from pathlib import Path
+from shlex import split
+
+from xdg import BaseDirectory
+
+from cpupower_gui.utils import read_govs, read_freq_lims, cpus_available, parse_core_list
+
+
+XDG_PATH = Path(BaseDirectory.save_config_path("cpupower_gui"))
+
+
+class CpuPowerConfig:
+    """cpupower configuration class"""
+
+    etc_conf = Path("/etc/cpupower_gui.conf")
+    etc_confd = Path("/etc/cpupower_gui.d")
+    user_conf = XDG_PATH
+
+    def __init__(self):
+        self.config = ConfigParser()
+        self.config.add_section("Profile")
+        self.config.set("Profile", "profile", "Balanced")
+        self._profiles = {}
+        # Initialise class
+        self._generate_default_profiles()
+        self.read_configuration()
+        self.read_profiles()
+
+    def read_configuration(self):
+        """Read and parse configuration files from
+        /etc/cpupower_gui.d/ and XDG_CONFIG_HOME
+
+        """
+        if self.etc_conf.exists():
+            self.config.read(self.etc_conf)
+
+        # drop-in configuration
+        if self.etc_confd.exists():
+            confd_files = sorted(self.etc_confd.glob("*.conf"))
+            if confd_files:
+                self.config.read(confd_files)
+
+        # user configuration
+        conf_files = sorted(self.user_conf.glob("*.conf"))
+        if conf_files:
+            self.config.read(conf_files)
+
+    def read_profiles(self):
+        """Read .profile files from configuration directories"""
+        files = self.user_conf.glob("*.profile")
+        for file in files:
+            prof = Profile(file)
+            self._profiles.update({prof.name: prof})
+
+    @property
+    def default_profile(self):
+        """Returns selected profile
+
+        Returns:
+            default_profile: Default profile name
+        """
+        return self.config["Profile"].get("profile")
+
+    @property
+    def profiles(self):
+        """Return list with profiles"""
+        return list(self._profiles.keys())
+
+    def get_profile(self, name):
+        """Return named profile object
+        Args:
+            name: Name of the profile
+
+        Returns:
+            profile: Profile object
+
+        """
+        return self._profiles.get(name)
+
+    def get_profile_settings(self, name):
+        """Return profile settings
+
+        Args:
+            name: Name of the profile
+
+        Returns:
+            settings: Profile settings
+
+        """
+        if name in self._profiles:
+            return self._profiles[name].settings
+        return None
+
+    def _generate_default_profiles(self):
+        """Generate default profiles based on current hardware.
+        The two profiles generated are 'Balanced' and 'Performance'.
+        The profiles apply either powersaving or performance governor.
+
+        """
+        # Get a governor list from first cpu
+        govs = read_govs(0)
+        if not govs:
+            return
+
+        # generate balanced profile based on powersave/ondemand governor
+        if "powersave" in govs:
+            self._profiles["Balanced"] = DefaultProfile("Balanced", "powersave")
+        elif "ondemand" in govs:
+            self._profiles["Balanced"] = DefaultProfile("Balanced", "ondemand")
+
+        # generate performance profile based on performance governor
+        if "performance" in govs:
+            self._profiles["Performance"] = DefaultProfile("Performance", "performance")
+
+
+class Profile:
+    """Wrapper for .profile files"""
+    def __init__(self, filename=None):
+        self.settings = {}
+        self.name = ""
+        self.file = None
+        if filename:
+            self.file = Path(filename)
+            self.parse_file()
+
+    def parse_file(self):
+        """Parse .profile file"""
+        if not self.file.exists():
+            return
+
+        text = self.file.read_text().splitlines()
+        # read name
+        if "name:" in text[0]:
+            self.name = split(text[0])[-1]
+        else:
+            self.name = self.file.name
+
+        for line in text[1:]:
+            vals = split(line, comments=True)
+            if vals:
+                self.settings.update(self._read_values(*vals))
+
+    @staticmethod
+    def _read_values(cpus: str, fmin: str, fmax: str, governor: str, online="y"):
+        """Return settings dict from parsed settings
+
+        Args:
+            cpus: String with related cores
+            fmin: Minimum core frequency
+            fmax: Maximum core frequency
+            governor: Core governor
+            online: If core is online or offline
+
+        Returns:
+            settings (dict): Dictionary with parsed settings
+
+        """
+        settings = {}
+        # cpu, fmin, fmax, gov
+        cores = parse_core_list(cpus)
+        for core in cores:
+            # Skip core if not available
+            if core not in cpus_available():
+                continue
+
+            conf = {
+                "freqs": parse_freqs(core, fmin, fmax),
+                "governor": parse_governor(core, governor),
+                "online": parse_online(core, online),
+            }
+            settings.update({core: conf})
+        return settings
+
+
+class DefaultProfile(Profile):
+    """Class for the default profiles"""
+
+    def __init__(self, name: str, governor="-", fmin="-", fmax="-"):
+        super().__init__()
+        self.name = name
+        self._generate_profile(fmin, fmax, governor)
+
+    def _generate_profile(self, fmin: str, fmax: str, governor: str):
+        """Generate default settings
+
+        Args:
+            fmin: Minimum core frequency
+            fmax: Maximum core frequency
+            governor: Core governor
+
+        """
+        for core in cpus_available():
+            conf = self._read_values(str(core), fmin, fmax, governor)
+            self.settings.update(conf)
+
+
+#
+# Helper function for parsing profiles
+#
+
+
+def parse_freqs(cpu: int, fmin: str, fmax: str):
+    """Return valid fmin, fmax for cpu from config
+
+    Args:
+        cpu: The cpu to check as an integer
+        fmin: The minimum frequency
+        fmax: The maximum frequency
+
+    Returns:
+        fmin, fmax: A tuple with the frequencies
+
+    """
+    freq_min, freq_max = None, None
+    if cpu not in cpus_available():
+        return freq_min, freq_max
+
+    if fmin.isnumeric():
+        freq_min = int(fmin) * 1000
+    else:
+        fmin, _ = read_freq_lims(cpu)
+        freq_min = fmin
+
+    if fmax.isnumeric():
+        freq_max = int(fmax) * 1000
+    else:
+        _, fmax = read_freq_lims(cpu)
+        freq_max = fmax
+
+    return freq_min, freq_max
+
+
+def parse_governor(cpu: int, gov: str):
+    """Return valid governor for cpu from config
+
+    Args:
+        cpu: The cpu to check as an integer
+        gov: The governor value from config
+
+    Returns:
+        governor: A valid governor
+
+    """
+    if cpu not in cpus_available():
+        return None
+
+    governors = read_govs(cpu)
+    if not governors:
+        return None
+
+    if gov in governors:
+        return gov
+
+    return governors[0]
+
+
+def parse_online(cpu: int, online: str):
+    """Return valid online attribute for cpu from config
+
+    Args:
+        cpu: The cpu to check as an integer
+        online: The online value from config
+
+    Returns:
+        online: A valid online attribute value
+
+    """
+    if cpu not in cpus_available():
+        return None
+
+    if online.lower() in ["yes", "y", "1", "true"]:
+        return True
+
+    return False

--- a/cpupower_gui/cpupower-gui-helper.py.in
+++ b/cpupower_gui/cpupower-gui-helper.py.in
@@ -2,7 +2,7 @@
 # cpupower-gui-helper.py
 
 """
-Copyright (C) 2017-2018 [RnD]²
+Copyright (C) 2017-2020 [RnD]²
 
 This file is part of cpupower-gui.
 

--- a/cpupower_gui/cpupower-gui-helper.py.in
+++ b/cpupower_gui/cpupower-gui-helper.py.in
@@ -357,3 +357,6 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("\nThe cpupower_gui_helper will now close...")
         loop.quit()
+
+# vim:set filetype=python shiftwidth=4 softtabstop=4 expandtab:
+

--- a/cpupower_gui/cpupower-gui.in
+++ b/cpupower_gui/cpupower-gui.in
@@ -115,8 +115,8 @@ if __name__ == "__main__":
 
     if args.apply_config:
         print("Applying configuration... ")
-        apply_configuration(conf)
-        sys.exit(0)
+        ret = apply_configuration(conf)
+        sys.exit(ret)
 
     import gi
 

--- a/cpupower_gui/cpupower-gui.in
+++ b/cpupower_gui/cpupower-gui.in
@@ -31,8 +31,12 @@ localedir = "@localedir@"
 sys.path.insert(1, pkgdatadir)
 
 from cpupower_gui.config import CpuPowerConfig
-from cpupower_gui.helper import apply_cpu_profile
-
+from cpupower_gui.helper import (
+    apply_cpu_profile,
+    apply_configuration,
+    apply_balanced,
+    apply_performance,
+)
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 gettext.install("cpupower-gui", localedir)
@@ -48,15 +52,28 @@ parser.add_argument(
     "--version", action="version", version="%(prog)s {}".format(VERSION)
 )
 
-parser.add_argument(
+cmd_group = parser.add_mutually_exclusive_group()
+
+cmd_group.add_argument(
     "-l",
     "--list-profiles",
     action="store_true",
     help="List available cpupower profiles",
 )
 
+cmd_group.add_argument(
+    "--apply-config", action="store_true", help="Apply cpupower configuration",
+)
+
+cmd_group.add_argument(
+    "--apply-profile", type=str, metavar="PROFILE", help="Apply a cpupower profile",
+)
+
 parser.add_argument(
-    "--apply-profile", type=str, help="Apply a cpupower profile",
+    "-b", "--balanced", action="store_true", help="Change governor to balanced",
+)
+parser.add_argument(
+    "-p", "--performance", action="store_true", help="Change governor to performance",
 )
 
 parser.add_argument(
@@ -66,6 +83,14 @@ parser.add_argument(
 if __name__ == "__main__":
     args = parser.parse_args()
     conf = CpuPowerConfig()
+
+    if args.balanced:
+        apply_balanced()
+        sys.exit(0)
+
+    if args.performance:
+        apply_performance()
+        sys.exit(0)
 
     if args.list_profiles:  # List profiles
         profiles = conf.profiles
@@ -87,6 +112,11 @@ if __name__ == "__main__":
         else:
             print("Profile not found!")
             sys.exit(1)
+
+    if args.apply_config:
+        print("Applying configuration... ")
+        apply_configuration(conf)
+        sys.exit(0)
 
     import gi
 

--- a/cpupower_gui/cpupower-gui.in
+++ b/cpupower_gui/cpupower-gui.in
@@ -2,7 +2,7 @@
 
 # cpupower-gui.in
 #
-# Copyright 2019 Evangelos Rigas
+# Copyright 2019-2020 Evangelos Rigas
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cpupower_gui/cpupower-gui.in
+++ b/cpupower_gui/cpupower-gui.in
@@ -21,21 +21,83 @@ import os
 import sys
 import signal
 import gettext
+import argparse
 
-VERSION = '@VERSION@'
-pkgdatadir = '@pkgdatadir@'
-localedir = '@localedir@'
+
+VERSION = "@VERSION@"
+pkgdatadir = "@pkgdatadir@"
+localedir = "@localedir@"
 
 sys.path.insert(1, pkgdatadir)
-signal.signal(signal.SIGINT, signal.SIG_DFL)
-gettext.install('cpupower-gui', localedir)
 
-if __name__ == '__main__':
+from cpupower_gui.config import CpuPowerConfig
+from cpupower_gui.helper import apply_cpu_profile
+
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+gettext.install("cpupower-gui", localedir)
+
+# Add argparse options
+parser = argparse.ArgumentParser(
+    prog="cpupower-gui",
+    description="cpupower-gui - Set the scaling frequencies and governor of a CPU",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+
+parser.add_argument(
+    "--version", action="version", version="%(prog)s {}".format(VERSION)
+)
+
+parser.add_argument(
+    "-l",
+    "--list-profiles",
+    action="store_true",
+    help="List available cpupower profiles",
+)
+
+parser.add_argument(
+    "--apply-profile", type=str, help="Apply a cpupower profile",
+)
+
+parser.add_argument(
+    "--gapplication-service", action="store_true", help="Start gui from gapplication",
+)
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    conf = CpuPowerConfig()
+
+    if args.list_profiles:  # List profiles
+        profiles = conf.profiles
+        if profiles:
+            print("The available profiles are:")
+            for prof in profiles:
+                print("\t- {}".format(prof))
+            sys.exit(0)
+
+        print("No profiles were found!")
+        sys.exit(0)
+
+    if args.apply_profile:
+        prof = args.apply_profile
+        if prof in conf.profiles:
+            print("Applying profile: ", prof)
+            apply_cpu_profile(conf.get_profile(prof))
+            sys.exit(0)
+        else:
+            print("Profile not found!")
+            sys.exit(1)
+
     import gi
 
     from gi.repository import Gio
-    resource = Gio.Resource.load(os.path.join(pkgdatadir, 'cpupower-gui.gresource'))
+
+    resource = Gio.Resource.load(os.path.join(pkgdatadir, "cpupower-gui.gresource"))
     resource._register()
 
     from cpupower_gui import main
+
     sys.exit(main.main(VERSION))
+
+
+# vim:set filetype=python shiftwidth=4 softtabstop=4 expandtab:

--- a/cpupower_gui/helper.py
+++ b/cpupower_gui/helper.py
@@ -1,0 +1,40 @@
+"""Module for dbus helper"""
+
+import dbus
+
+BUS = dbus.SystemBus()
+SESSION = BUS.get_object(
+    "org.rnd2.cpupower_gui.helper", "/org/rnd2/cpupower_gui/helper"
+)
+
+HELPER = dbus.Interface(SESSION, "org.rnd2.cpupower_gui.helper")
+
+MSG = """Setting CPU: {}
+    Minimum Frequency: {} MHz, Maximum Frequency: {} MHz
+    Governor: {}, Online: {}
+"""
+
+
+def apply_cpu_profile(profile):
+    """Set cpu settings base on a profile
+
+    Args:
+        profile: A cpupower profile
+
+    """
+    settings = profile.settings
+    for cpu in settings.keys():
+        fmin, fmax = settings[cpu].get("freqs")
+        gov = settings[cpu].get("governor")
+        online = settings[cpu].get("online")
+        if fmin and fmax:
+            HELPER.update_cpu_settings(cpu, fmin, fmax)
+        if gov:
+            HELPER.update_cpu_governor(cpu, gov)
+        if online is not None:
+            if HELPER.cpu_allowed_offline(cpu):
+                if online:
+                    HELPER.set_cpu_online(cpu)
+                else:
+                    HELPER.set_cpu_offline(cpu)
+        print(MSG.format(cpu, fmin/1e3, fmax/1e3, gov.capitalize(), online))

--- a/cpupower_gui/helper.py
+++ b/cpupower_gui/helper.py
@@ -23,6 +23,10 @@ def apply_cpu_profile(profile):
 
     """
     settings = profile.settings
+    if not HELPER.isauthorized():
+        print("User is not authorised. No changes applied.")
+        return -1
+
     for cpu in settings.keys():
         fmin, fmax = settings[cpu].get("freqs")
         gov = settings[cpu].get("governor")
@@ -50,12 +54,16 @@ def apply_configuration(config):
     # TODO: Allow extra configuration to take place
     profile = config.default_profile
     if not profile in config.profiles:
-        return
+        return -1
 
     apply_cpu_profile(config.get_profile(profile))
 
 def apply_performance():
     """Set CPU governor to performance"""
+    if not HELPER.isauthorized():
+        print("User is not authorised. No changes applied.")
+        return -1
+
     for cpu in HELPER.get_cpus_available():
         gov = "performance"
         if dbus.String(gov) not in HELPER.get_cpu_governors(cpu):
@@ -63,13 +71,19 @@ def apply_performance():
             if dbus.String(gov) not in HELPER.get_cpu_governors(cpu):
                 print("Failed to set governor to performance")
 
-        if HELPER.isauthorized():
-            ret = HELPER.update_cpu_governor(cpu, gov)
-            if ret == 0:
-                print("Set CPU {} to {}".format(int(cpu), gov))
+
+        ret = HELPER.update_cpu_governor(cpu, gov)
+        if ret == 0:
+            print("Set CPU {} to {}".format(int(cpu), gov))
+
+    return 0
 
 def apply_balanced():
     """Set CPU governor to powersave or ondemand"""
+    if not HELPER.isauthorized():
+        print("User is not authorised. No changes applied.")
+        return -1
+
     for cpu in HELPER.get_cpus_available():
         govs = HELPER.get_cpu_governors(cpu)
         for governor in govs:
@@ -81,7 +95,8 @@ def apply_balanced():
             print("Failed to get default governor for CPU {}.".format(int(cpu)))
             continue
 
-        if HELPER.isauthorized():
-            ret = HELPER.update_cpu_governor(cpu, gov)
-            if ret == 0:
-                print("Set CPU {} to {}".format(int(cpu), gov))
+        ret = HELPER.update_cpu_governor(cpu, gov)
+        if ret == 0:
+            print("Set CPU {} to {}".format(int(cpu), gov))
+
+    return 0

--- a/cpupower_gui/meson.build
+++ b/cpupower_gui/meson.build
@@ -47,6 +47,9 @@ cpupower_gui_sources = [
   '__init__.py',
   'main.py',
   'window.py',
+  'config.py',
+  'utils.py',
+  'helper.py'
 ]
 
 install_data(cpupower_gui_sources, install_dir: moduledir)

--- a/cpupower_gui/meson.build
+++ b/cpupower_gui/meson.build
@@ -8,7 +8,7 @@ python = import('python')
 conf = configuration_data()
 conf.set('PYTHON', python.find_installation('python3').path())
 conf.set('VERSION', meson.project_version())
-conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set('localedir', join_paths(prefix, get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)
 
 configure_file(

--- a/cpupower_gui/utils.py
+++ b/cpupower_gui/utils.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+SYS_PATH = "/sys/devices/system/cpu/cpu{}/cpufreq"
+FREQ_MIN = "scaling_min_freq"
+FREQ_MAX = "scaling_max_freq"
+FREQ_MIN_HW = "cpuinfo_min_freq"
+FREQ_MAX_HW = "cpuinfo_max_freq"
+AVAIL_GOV = "scaling_available_governors"
+GOVERNOR = "scaling_governor"
+ONLINE = Path("/sys/devices/system/cpu/online")
+PRESENT = Path("/sys/devices/system/cpu/present")
+ONLINE_PATH = "/sys/devices/system/cpu/cpu{}/online"
+
+
+def parse_core_list(string):
+    """Parse string of cores like '0,2,4-10,12' into a list """
+    cores = []
+    for elem in string.split(","):
+        if "-" in elem:
+            start, end = [int(c) for c in elem.split("-")]
+            cores.extend(range(start, end + 1))
+        else:
+            cores.append(int(elem))
+    return cores
+
+
+def cpus_present():
+    """Returns a list of present CPUs """
+    cpus = PRESENT.read_text().strip()
+    return parse_core_list(cpus)
+
+
+def cpus_online():
+    """Returns a list of online CPUs """
+    cpus = ONLINE.read_text().strip()
+    return parse_core_list(cpus)
+
+
+def cpus_offline():
+    """Returns a list of offline CPUs """
+    online = cpus_online()
+    present = cpus_present()
+    return [cpu for cpu in present if cpu not in online]
+
+
+def cpus_available():
+    online = cpus_present()
+    avail = []
+    for cpu in online:
+        sys_path = Path(SYS_PATH.format(cpu))
+        if (
+            (sys_path / FREQ_MIN_HW).exists()
+            and (sys_path / FREQ_MAX_HW).exists()
+            and (sys_path / AVAIL_GOV).exists()
+        ):
+            avail.append(cpu)
+    return avail
+
+
+def read_freqs(cpu):
+    """ Reads frequencies from sysfs """
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+
+    freq_min = int((sys_path / FREQ_MIN).read_text())
+    freq_max = int((sys_path / FREQ_MAX).read_text())
+
+    return freq_min, freq_max
+
+
+def read_freq_lims(cpu):
+    """ Reads frequency limits from sysfs """
+    try:
+        sys_path = Path(SYS_PATH.format(int(cpu)))
+        freq_minhw = int((sys_path / FREQ_MIN_HW).read_text())
+        freq_maxhw = int((sys_path / FREQ_MAX_HW).read_text())
+
+        return freq_minhw, freq_maxhw
+    except Exception as exc:
+        print("WARNING! Unknown CPU frequency, cause:", exc)
+
+    return 0, 0
+
+
+def read_govs(cpu):
+    """ Reads governors from sysfs """
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    try:
+        sys_file = sys_path / AVAIL_GOV
+        govs = sys_file.read_text().strip().split(" ")
+    except OSError:
+        govs = []
+    finally:
+        return govs
+
+
+def read_governor(cpu):
+    """ Reads governor from sysfs """
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    try:
+        sys_file = sys_path / GOVERNOR
+        governor = sys_file.read_text().strip()
+    except OSError:
+        governor = "ERROR"
+    finally:
+        return governor

--- a/cpupower_gui/window.py
+++ b/cpupower_gui/window.py
@@ -20,6 +20,7 @@ import sys
 import dbus
 
 from gi.repository import Gtk, Gio
+from .config import CpuPowerConfig
 
 BUS = dbus.SystemBus()
 SESSION = BUS.get_object(
@@ -68,10 +69,12 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.config = CpuPowerConfig().get_gui_settings()
         self.conf_store = {}
         self.refreshing = False
         self.init_conf_store()
         self.update_cpubox()
+        self.configure_gui()
         self.upd_sliders()
 
         # Application actions
@@ -100,6 +103,12 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
             self.cpu_store.append([cpu, "black"])
 
         self.cpu_box.set_active(0)
+
+    def configure_gui(self):
+        """Configures GUI based on the config file"""
+        # To all cpus toggle
+        toggle_default = self.config.getboolean("toall_default", False)
+        self.toall.set_active(toggle_default)
 
     def quit(self, *args):
         """Quit"""

--- a/cpupower_gui/window.ui.in
+++ b/cpupower_gui/window.ui.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.2 
 
-Copyright (C) 2019 [RnD]²
+Copyright (C) 2019-2020 [RnD]²
 
 This file is part of cpupower-gui.
 

--- a/data/cpupower_gui.conf
+++ b/data/cpupower_gui.conf
@@ -1,0 +1,15 @@
+# Cpupower-gui configuration
+#
+# Profile section has a profile key to set the profile to apply.
+# Additional configuration options will be added over time.
+#
+# You can either change the configuration here or
+# add drop-in files in /etc/cpupower_gui.d/ that will
+# override the settings in this file.
+#
+# For more info on drop-in files read /etc/cpupower_gui.d/README
+#
+
+[Profile]
+profile=Balanced
+

--- a/data/cpupower_gui.conf
+++ b/data/cpupower_gui.conf
@@ -13,3 +13,5 @@
 [Profile]
 profile=Balanced
 
+[GUI]
+allcpus_default=False

--- a/data/cpupower_gui.d/README
+++ b/data/cpupower_gui.d/README
@@ -1,0 +1,45 @@
+# Cpupower-gui configuration
+
+cpupower-gui first tries to read the configuration from `/etc/cpupower_gui.conf`.
+Then it will read any `.conf` file in this directory (`/etc/cpupower_gui.d/`)
+in alphabetical order. The options defined on the last read file take precedence.
+
+For example, if threre are two files, named `10-config.conf` and `20-overrides.conf`, the shared options from the first will be overriden.
+
+Simillarly, files found in `$XDG_CONFIG_HOME/cpupower_gui/`, which usually points to `~/.config/cpupower_gui/`, will take precedence over the system-wide ones.
+
+
+# Profiles
+
+Profile files are text files with a `.profile` extension.
+The file must start with the following line:
+```
+# name: My_Profile
+```
+
+If profile name contains spaces it must be quoted like:
+```
+# name: "My awesome profile"
+```
+
+The profile settings have the following format:
+```
+# CPU MIN MAX GOVERNOR ONLINE(Optional)
+0-2  2500 3000 performance y
+```
+The options are separated with whitespace (spaces/tabs).
+
+For the cpu option valid values are the either a number or a range.
+For example, `0-2` sets the cores 0, 1, 2 (that is the first three cores).
+
+For the minimum and maximum frequency the values must be the clock frequency in MHz.
+If you want to omit a value use `-` and it will be set to the hardware frequency limit.
+
+For the governor value, either use the name of the governor or `-`.
+If `-` is used, then the first available governor will be selected.
+
+Lastly, for online option, you can omit the value or use:
+- `y`, `yes`, `true`, `1` to enable.
+- `n`, `no`, `false`, `0` to disable.
+
+An example profile is available at `/etc/cpupower_gui.d/my_profile.profile.ex

--- a/data/cpupower_gui.d/my_profile.profile.ex
+++ b/data/cpupower_gui.d/my_profile.profile.ex
@@ -1,0 +1,5 @@
+# name: "Custom"
+
+# CPU  Fmin   Fmax  Governor      Online
+0-2    2200   2800   performance
+3-5    2400   3200   ondemand

--- a/data/meson.build
+++ b/data/meson.build
@@ -56,6 +56,9 @@ if compile_schemas.found()
   )
 endif
 
+install_subdir('cpupower_gui.d', install_dir: get_option('sysconfdir'))
+install_data('cpupower_gui.conf', install_dir: get_option('sysconfdir'))
+
 
 subdir('services')
 subdir('polkit')

--- a/data/services/cpupower-gui-user.service
+++ b/data/services/cpupower-gui-user.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Apply cpupower-gui config at user login
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cpupower-gui --apply-config
+
+[Install]
+WantedBy=graphical-session.target
+

--- a/data/services/cpupower-gui.service
+++ b/data/services/cpupower-gui.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Apply cpupower-gui config at boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cpupower-gui --apply-config
+
+[Install]
+WantedBy=multi-user.target
+

--- a/data/services/meson.build
+++ b/data/services/meson.build
@@ -1,4 +1,4 @@
-pkglibdir = join_paths(get_option('prefix'), get_option('libdir'),
+pkglibdir = join_paths(prefix, get_option('libdir'),
                        meson.project_name())
 
 dbus_dir = join_paths(get_option('datadir'), 'dbus-1')
@@ -6,7 +6,7 @@ systemd_dir = get_option('systemddir')
 
 service_conf = configuration_data() 
 service_conf.set('pkglibdir', pkglibdir)
-service_conf.set('bindir', join_paths(get_option('prefix'),
+service_conf.set('bindir', join_paths(prefix,
                                       get_option('bindir')))
 
 systemd_service  = configure_file(

--- a/data/services/meson.build
+++ b/data/services/meson.build
@@ -37,3 +37,15 @@ install_data(
     'org.rnd2.cpupower_gui.helper.conf', 
     install_dir : join_paths(dbus_dir, 'system.d')
 )
+
+# SystemD system unit to apply config at boot
+install_data(
+    'cpupower-gui.service',
+    install_dir: join_paths(systemd_dir, 'system')
+)
+
+# SystemD user unit to apply config at login
+install_data(
+    'cpupower-gui-user.service',
+    install_dir: join_paths(prefix, 'lib/systemd/user')
+)

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ project('cpupower-gui',
     ],
   )
 
+prefix = get_option('prefix')
+
 i18n = import('i18n')
 
 application_id = 'org.rnd2.cpupower_gui'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('systemddir', type : 'string',
-       description : '''Set the path for systemd units [default '/lib/systemd']''')
+       description : '''Set the path for systemd units [default '/usr/lib/systemd']''')
 

--- a/org.rnd2.CpupowerGui.json
+++ b/org.rnd2.CpupowerGui.json
@@ -1,10 +1,10 @@
 {
-    "app-id": "org.rnd2.CpupowerGui",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
-    "sdk": "org.gnome.Sdk",
-    "command": "cpupower-gui",
-    "finish-args": [
+    "app-id" : "org.rnd2.CpupowerGui",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.36",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "cpupower-gui",
+    "finish-args" : [
         "--share=network",
         "--share=ipc",
         "--socket=x11",
@@ -16,7 +16,7 @@
         "--system-own-name=org.rnd2.cpupower_gui.helper",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "cleanup": [
+    "cleanup" : [
         "/include",
         "/lib/pkgconfig",
         "/man",
@@ -28,33 +28,37 @@
         "*.la",
         "*.a"
     ],
-    "modules": [
+    "modules" : [
         {
-            "name": "cpupower-gui",
-            "builddir": true,
-            "buildsystem": "meson",
-            "sources": [
-                    {
-                        "type": "git",
-                        "url": "https://gitlab.com/vagnum08/cpupower-gui"
-                    }
+            "name" : "cpupower-gui",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.com/vagnum08/cpupower-gui"
+                }
             ],
-            "config-opts": []
+            "config-opts" : [
+            ]
         },
         {
-            "name": "dbus-python",
-            "buildsystem": "simple",
-            "build-commands": [
+            "name" : "dbus-python",
+            "buildsystem" : "simple",
+            "build-commands" : [
                 "pip3 install --prefix=${FLATPAK_DEST} dbus-python==1.2.16"
             ],
-            "sources": [
-                    {
-                        "type": "file",
-                        "url": "https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.2.16.tar.gz",
-                        "sha256": "11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4"
-                    }
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.2.16.tar.gz",
+                    "sha256" : "11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4"
+                }
             ]
         }
-    ]
+    ],
+    "build-options" : {
+        "env" : {
+        }
+    }
 }
-


### PR DESCRIPTION
Adds the ability to configure the cpupower-gui using configuration files from `/etc/cpupower_gui.d/` and `~/.config/cpupower_gui/`.

Additionally, profile files can be defined to configure the cpu frequencies and governors.

Last, add systemd units to set the profiles during boot or user login.

Closes: #13, #24 