### PR TITLE
Add frequency marks on the sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ When the user logs into the system, their settings will automatically apply.
 Notes:
 - The `cpupower-gui-user.service` currently depends on `graphical.target`. This is tested and works with Gnome Shell. If it doesn't work on a different display manager, open an issue.
 - To apply the settings during login the user must be active and local to the system. This means that the user must have access to the hardware, so it won't work when the user logs in through `ssh`.
-- To apply the settings over `ssh` the user will need root access.
+- To apply the settings over `ssh` the user will need root access.
 
 ## Enabling extra governors
 By default, `cpupower-gui` will only show the available governors for each cpu.

--- a/cpupower_gui/utils.py
+++ b/cpupower_gui/utils.py
@@ -5,6 +5,7 @@ FREQ_MIN = "scaling_min_freq"
 FREQ_MAX = "scaling_max_freq"
 FREQ_MIN_HW = "cpuinfo_min_freq"
 FREQ_MAX_HW = "cpuinfo_max_freq"
+AVAIL_FREQS = "scaling_available_frequencies"
 AVAIL_GOV = "scaling_available_governors"
 GOVERNOR = "scaling_governor"
 ONLINE = Path("/sys/devices/system/cpu/online")
@@ -91,6 +92,18 @@ def read_govs(cpu):
         govs = []
     finally:
         return govs
+
+
+def read_available_frequencies(cpu):
+    """ Reads governors from sysfs """
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    try:
+        sys_file = sys_path / AVAIL_FREQS
+        freqs = sys_file.read_text().strip().split(" ")
+    except OSError:
+        freqs = []
+    finally:
+        return freqs
 
 
 def read_governor(cpu):

--- a/cpupower_gui/window.py
+++ b/cpupower_gui/window.py
@@ -438,6 +438,7 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
         profile = mod[self.profile_box.get_active_iter()][0]
         # Update store
         res = self._set_profile_settings(profile)
+        self.toall.set_active(False) # Disable toggle
         self.upd_sliders()
         self.apply_btn.set_sensitive(res)
 
@@ -473,6 +474,7 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
                     self._update_cpu_foreground(cpu, False)
 
             # Update sliders
+            self.profile_box.set_active(0)
             self.init_conf_store()
             self.upd_sliders()
 


### PR DESCRIPTION
On some systems there is a scaling_available_frequencies file (`sys/device/system/cpu/cpu*/cpufreq/scaling_available_frequencies`).
This file reports the frequency steps of the hardware.

In this pull request a function is added to read this file and report a list of the available frequencies.
If the file is available, the GUI will show a mark above the slider along with the frequency in GHz.

Closes #14


![2020-10-11-213116](https://user-images.githubusercontent.com/16070176/95689509-2e8a8100-0c09-11eb-895f-fdb981eb19b0.png)
