### PR TITLE
Add Intel pstate energy performance preferences

### DIFF
--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -303,8 +303,14 @@ def parse_online(cpu: int, online: str):
 class CpuSettings:
     """Abstraction class for cpu settings"""
 
+    units = {
+        "mhz": 1e3,
+        "ghz": 1e6,
+        }
+
     def __init__(self, cpu):
         self.cpu = cpu
+        self._factor = self.units["mhz"]
         self._settings = {}
         self._new_settings = {}
         # Attributes that don't change
@@ -337,11 +343,13 @@ class CpuSettings:
     @property
     def freqs(self):
         freqs = self._new_settings["freqs"]
-        return int(freqs[0] / 1e3), int(freqs[1] / 1e3)
+        f = self._factor
+        return freqs[0] / f, freqs[1] / f
 
     @freqs.setter
     def freqs(self, freqs):
-        self._new_settings["freqs"] = (int(freqs[0] * 1e3), int(freqs[1] * 1e3))
+        f = self._factor
+        self._new_settings["freqs"] = (int(freqs[0] * f), int(freqs[1] * f))
 
     @property
     def freqs_scaled(self):
@@ -376,7 +384,8 @@ class CpuSettings:
     @property
     def hw_lims(self):
         freqs = self._lims
-        return int(freqs[0] / 1e3), int(freqs[1] / 1e3)
+        f = self._factor
+        return freqs[0] / f, freqs[1] / f
 
     @property
     def online(self):
@@ -385,3 +394,9 @@ class CpuSettings:
     @online.setter
     def online(self, on):
         self._new_settings["online"] = bool(on)
+
+    def set_units(self, unit: str):
+        unit = unit.lower()
+        if unit not in self.units.keys():
+            return
+        self._factor = self.units[unit]

--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -4,7 +4,13 @@ from configparser import ConfigParser
 from pathlib import Path
 from shlex import split
 
-from xdg import BaseDirectory
+try:
+    from xdg import BaseDirectory
+
+    XDG_PATH = Path(BaseDirectory.save_config_path("cpupower_gui"))
+except ImportError:
+    BaseDirectory = None
+    XDG_PATH = None
 
 from cpupower_gui.utils import (
     read_govs,
@@ -15,9 +21,6 @@ from cpupower_gui.utils import (
     is_online,
     parse_core_list,
 )
-
-
-XDG_PATH = Path(BaseDirectory.save_config_path("cpupower_gui"))
 
 
 class CpuPowerConfig:
@@ -53,9 +56,10 @@ class CpuPowerConfig:
                 self.config.read(confd_files)
 
         # user configuration
-        conf_files = sorted(self.user_conf.glob("*.conf"))
-        if conf_files:
-            self.config.read(conf_files)
+        if self.user_conf:
+            conf_files = sorted(self.user_conf.glob("*.conf"))
+            if conf_files:
+                self.config.read(conf_files)
 
     def _read_profiles(self):
         """Read .profile files from configuration directories"""
@@ -115,7 +119,7 @@ class CpuPowerConfig:
     def _generate_default_profiles(self):
         """Generate default profiles based on current hardware.
         The two profiles generated are 'Balanced' and 'Performance'.
-        The profiles apply either powersaving or performance governor.
+        The profiles apply either power-saving or performance governor.
 
         """
         # Get a governor list from first cpu

--- a/cpupower_gui/cpupower-gui-helper.py.in
+++ b/cpupower_gui/cpupower-gui-helper.py.in
@@ -22,14 +22,20 @@ along with cpupower-gui.  If not, see <http://www.gnu.org/licenses/>.
 Author: Evangelos Rigas <erigas@rnd2.org>
 """
 
-import os
-import locale
-import gettext
+import sys
 
-from gi.repository import GLib
+sys.path.insert(1, "@pkgdatadir@")
+
+import gettext
+import locale
+from pathlib import Path
+
 import dbus
 import dbus.service
 from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+
+import cpupower_gui.utils as util
 
 localedir = "@localedir@"
 
@@ -41,115 +47,9 @@ gettext.textdomain("cpupower-gui")
 SYS_PATH = "/sys/devices/system/cpu/cpu{}/cpufreq"
 FREQ_MIN = "scaling_min_freq"
 FREQ_MAX = "scaling_max_freq"
-FREQ_MIN_HW = "cpuinfo_min_freq"
-FREQ_MAX_HW = "cpuinfo_max_freq"
-AVAIL_GOV = "scaling_available_governors"
 GOVERNOR = "scaling_governor"
-ONLINE = "/sys/devices/system/cpu/online"
-PRESENT = "/sys/devices/system/cpu/present"
 ONLINE_PATH = "/sys/devices/system/cpu/cpu{}/online"
-
-
-def parse_corelist(string):
-    """Parse string of cores like '0,2,4-10,12' into a list """
-    a = []
-    for el in string.split(","):
-        if "-" in el:
-            b, e = [int(c) for c in el.split("-")]
-            a.extend(range(b, e + 1))
-        else:
-            a.append(int(el))
-    return a
-
-
-def cpus_present():
-    """Returns a list of present CPUs """
-    with open(PRESENT, "r") as sys_file:
-        cpus_present = sys_file.readline().strip()
-
-    return parse_corelist(cpus_present)
-
-
-def cpus_online():
-    """Returns a list of online CPUs """
-    with open(ONLINE, "r") as sys_file:
-        cpus = sys_file.readline().strip()
-
-    return parse_corelist(cpus)
-
-
-def cpus_offline():
-    """Returns a list of offline CPUs """
-    online = cpus_online()
-    present = cpus_present()
-    return [cpu for cpu in present if cpu not in online]
-
-
-def cpus_available():
-    online = cpus_present()
-    avail = []
-    for cpu in online:
-        sys_path = SYS_PATH.format(cpu)
-        if (
-            os.path.exists(os.path.join(sys_path, FREQ_MIN_HW))
-            and os.path.exists(os.path.join(sys_path, FREQ_MAX_HW))
-            and os.path.exists(os.path.join(sys_path, AVAIL_GOV))
-        ):
-            avail.append(cpu)
-    return avail
-
-
-def read_freqs(cpu):
-    """ Reads frequencies from sysfs """
-    sys_path = SYS_PATH.format(int(cpu))
-    with open(os.path.join(sys_path, FREQ_MIN), "r") as sys_file:
-        freq_min = int(sys_file.readline())
-
-    with open(os.path.join(sys_path, FREQ_MAX), "r") as sys_file:
-        freq_max = int(sys_file.readline())
-
-    return freq_min, freq_max
-
-
-def read_freq_lims(cpu):
-    """ Reads frequency limits from sysfs """
-    try:
-        sys_path = SYS_PATH.format(int(cpu))
-        with open(os.path.join(sys_path, FREQ_MIN_HW), "r") as sys_file:
-            freq_minhw = int(sys_file.readline())
-
-        with open(os.path.join(sys_path, FREQ_MAX_HW), "r") as sys_file:
-            freq_maxhw = int(sys_file.readline())
-
-        return freq_minhw, freq_maxhw
-    except Exception as e:
-        print("WARNING! Unknown CPU frequency, cause:", e)
-
-    return 0, 0
-
-
-def read_govs(cpu):
-    """ Reads governors from sysfs """
-    sys_path = SYS_PATH.format(int(cpu))
-    try:
-        with open(os.path.join(sys_path, AVAIL_GOV), "r") as sys_file:
-            govs = sys_file.readline().strip().split(" ")
-    except OSError as e:
-        govs = []
-    finally:
-        return govs
-
-
-def read_governor(cpu):
-    """ Reads governor from sysfs """
-    sys_path = SYS_PATH.format(int(cpu))
-    try:
-        with open(os.path.join(sys_path, GOVERNOR), "r") as sys_file:
-            governor = sys_file.readline().strip()
-    except OSError as e:
-        governor = "ERROR"
-    finally:
-        return governor
+PERF_PREF = "energy_performance_preference"
 
 
 class CpupowerGui_DBus(dbus.service.Object):
@@ -171,7 +71,7 @@ class CpupowerGui_DBus(dbus.service.Object):
         self.cancellation_id = ""  # No cancellation id
 
     def _is_authorized(self, sender, action_id="org.rnd2.cpupower_gui.apply_runtime"):
-        """"Checks if sender is authorized to perform the action with action_id
+        """Checks if sender is authorized to perform the action with action_id
 
         Args:
             sender: D-Bus client name
@@ -206,7 +106,7 @@ class CpupowerGui_DBus(dbus.service.Object):
     )
     def get_cpu_frequencies(self, cpu):
         if self.is_present(cpu) and self.is_online(cpu):
-            return read_freqs(cpu)
+            return util.read_freqs(cpu)
         return 0, 0
 
     @dbus.service.method(
@@ -214,7 +114,7 @@ class CpupowerGui_DBus(dbus.service.Object):
     )
     def get_cpu_limits(self, cpu):
         if self.is_present(cpu) and self.is_online(cpu):
-            return read_freq_lims(cpu)
+            return util.read_freq_lims(cpu)
         return 0, 0
 
     @dbus.service.method(
@@ -222,37 +122,54 @@ class CpupowerGui_DBus(dbus.service.Object):
     )
     def get_cpu_governors(self, cpu):
         if self.is_present(cpu) and self.is_online(cpu):
-            return read_govs(cpu)
+            return util.read_govs(cpu)
+        return [""]
+
+    @dbus.service.method(
+        "org.rnd2.cpupower_gui.helper", in_signature="i", out_signature="as"
+    )
+    def get_cpu_energy_preferences(self, cpu):
+        if self.is_present(cpu) and self.is_online(cpu):
+            return util.read_available_energy_prefs(cpu)
         return [""]
 
     @dbus.service.method("org.rnd2.cpupower_gui.helper", out_signature="ai")
     def get_cpus_online(self):
-        return cpus_online()
+        return util.cpus_online()
 
     @dbus.service.method("org.rnd2.cpupower_gui.helper", out_signature="ai")
     def get_cpus_offline(self):
-        return cpus_offline()
+        return util.cpus_offline()
 
     @dbus.service.method("org.rnd2.cpupower_gui.helper", out_signature="ai")
     def get_cpus_available(self):
-        return cpus_available()
+        return util.cpus_available()
 
     @dbus.service.method("org.rnd2.cpupower_gui.helper", out_signature="ai")
     def get_cpus_present(self):
-        return cpus_present()
+        return util.cpus_present()
 
     @dbus.service.method(
         "org.rnd2.cpupower_gui.helper", in_signature="i", out_signature="i"
     )
     def cpu_allowed_offline(self, cpu):
-        return int(os.path.exists(ONLINE_PATH.format(cpu)))
+        path = Path(ONLINE_PATH.format(cpu))
+        return int(path.exists())
 
     @dbus.service.method(
         "org.rnd2.cpupower_gui.helper", in_signature="i", out_signature="s"
     )
     def get_cpu_governor(self, cpu):
         if self.is_present(cpu) and self.is_online(cpu):
-            return read_governor(cpu)
+            return util.read_governor(cpu)
+        return ""
+
+    @dbus.service.method(
+        "org.rnd2.cpupower_gui.helper", in_signature="i", out_signature="s"
+    )
+    def get_cpu_energy_preference(self, cpu):
+        if self.is_present(cpu) and self.is_online(cpu):
+            return util.read_energy_pref(cpu)
         return ""
 
     @dbus.service.method(
@@ -276,9 +193,8 @@ class CpupowerGui_DBus(dbus.service.Object):
     )
     def set_cpu_online(self, cpu, sender=None):
         if self._is_authorized(sender):
-            sys_path = ONLINE_PATH.format(cpu)
-            with open(os.path.join(sys_path), "w") as sys_file:
-                sys_file.write("1")
+            sys_file = Path(ONLINE_PATH.format(cpu))
+            sys_file.write_text("1")
             return 0
         else:
             return -1
@@ -291,9 +207,8 @@ class CpupowerGui_DBus(dbus.service.Object):
     )
     def set_cpu_offline(self, cpu, sender=None):
         if self._is_authorized(sender):
-            sys_path = ONLINE_PATH.format(cpu)
-            with open(os.path.join(sys_path), "w") as sys_file:
-                sys_file.write("0")
+            sys_file = Path(ONLINE_PATH.format(cpu))
+            sys_file.write_text("0")
             return 0
         else:
             return -1
@@ -312,6 +227,22 @@ class CpupowerGui_DBus(dbus.service.Object):
             return -1
 
     @dbus.service.method(
+        "org.rnd2.cpupower_gui.helper",
+        in_signature="is",
+        out_signature="i",
+        sender_keyword="sender",
+    )
+    def update_cpu_energy_prefs(self, cpu, pref, sender=None):
+        if pref not in util.read_available_energy_prefs(cpu):
+            return 0
+
+        if self._is_authorized(sender):
+            ret = self._update_cpu_energy_prefs(int(cpu), str(pref))
+            return ret
+        else:
+            return -1
+
+    @dbus.service.method(
         "org.rnd2.cpupower_gui.helper", sender_keyword="sender", out_signature="i"
     )
     def isauthorized(self, sender=None):
@@ -323,20 +254,22 @@ class CpupowerGui_DBus(dbus.service.Object):
 
     @staticmethod
     def is_online(cpu):
-        return cpu in cpus_online()
+        return cpu in util.cpus_online()
 
     @staticmethod
     def is_present(cpu):
-        return cpu in cpus_present()
+        return cpu in util.cpus_present()
 
     def _update_cpu(self, cpu, fmin, fmax):
         if self.is_present(cpu) and self.is_online(cpu):
             try:
-                sys_path = SYS_PATH.format(cpu)
-                with open(os.path.join(sys_path, FREQ_MIN), "w") as sys_file:
-                    sys_file.write(str(fmin))
-                with open(os.path.join(sys_path, FREQ_MAX), "w") as sys_file:
-                    sys_file.write(str(fmax))
+                sys_path = Path(SYS_PATH.format(cpu))
+
+                sys_file = sys_path / FREQ_MIN
+                sys_file.write_text(str(fmin))
+
+                sys_file = sys_path / FREQ_MAX
+                sys_file.write_text(str(fmax))
                 return 0
             except IOError as e:
                 return -13
@@ -346,9 +279,22 @@ class CpupowerGui_DBus(dbus.service.Object):
     def _update_cpu_governor(self, cpu, governor):
         if self.is_present(cpu) and self.is_online(cpu):
             try:
-                sys_path = SYS_PATH.format(cpu)
-                with open(os.path.join(sys_path, GOVERNOR), "w") as sys_file:
-                    sys_file.write(governor)
+                sys_path = Path(SYS_PATH.format(cpu))
+                sys_file = sys_path / GOVERNOR
+                sys_file.write_text(governor)
+                return 0
+            except IOError as e:
+                return -13
+        else:
+            return -1
+
+    def _update_cpu_energy_prefs(self, cpu, pref):
+        if self.is_present(cpu) and self.is_online(cpu):
+            try:
+                sys_path = Path(SYS_PATH.format(cpu))
+                sys_file = sys_path / PERF_PREF
+                if sys_file.exists():
+                    sys_file.write_text(pref)
                 return 0
             except IOError as e:
                 return -13
@@ -373,4 +319,3 @@ if __name__ == "__main__":
         loop.quit()
 
 # vim:set filetype=python shiftwidth=4 softtabstop=4 expandtab:
-

--- a/cpupower_gui/main.py
+++ b/cpupower_gui/main.py
@@ -30,7 +30,7 @@ from gi.repository import Gtk, Gio, GLib
 try:
     gi.require_version("AppIndicator3", "0.1")
     from gi.repository import AppIndicator3 as AppIndicator
-except:
+except ImportError:
     AppIndicator = None
 
 from .window import CpupowerGuiWindow

--- a/cpupower_gui/utils.py
+++ b/cpupower_gui/utils.py
@@ -7,6 +7,8 @@ FREQ_MIN_HW = "cpuinfo_min_freq"
 FREQ_MAX_HW = "cpuinfo_max_freq"
 AVAIL_FREQS = "scaling_available_frequencies"
 AVAIL_GOV = "scaling_available_governors"
+AVAIL_PERF_PREF = "energy_performance_available_preferences"
+PERF_PREF = "energy_performance_preference"
 GOVERNOR = "scaling_governor"
 ONLINE = Path("/sys/devices/system/cpu/online")
 PRESENT = Path("/sys/devices/system/cpu/present")
@@ -132,3 +134,34 @@ def read_governor(cpu):
         governor = "ERROR"
     finally:
         return governor
+
+
+def read_available_energy_prefs(cpu):
+    """ Reads energy performance available preferences"""
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    try:
+        sys_file = sys_path / AVAIL_PERF_PREF
+        prefs = sys_file.read_text().strip().split(" ")
+    except OSError:
+        prefs = []
+    finally:
+        return prefs
+
+
+def read_energy_pref(cpu):
+    """ Reads energy performance available preferences"""
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    try:
+        sys_file = sys_path / PERF_PREF
+        pref = sys_file.read_text().strip()
+    except OSError:
+        pref = ""
+    finally:
+        return pref
+
+
+def is_energy_pref_avail(cpu):
+    """Check if Intel energy performance preferences are available"""
+    sys_path = Path(SYS_PATH.format(int(cpu)))
+    sys_file = sys_path / AVAIL_PERF_PREF
+    return sys_file.exists()

--- a/cpupower_gui/utils.py
+++ b/cpupower_gui/utils.py
@@ -58,6 +58,22 @@ def cpus_available():
     return avail
 
 
+def is_online(cpu):
+    """Wrapper to get the online state for a cpu
+
+    Args:
+        cpu: Index of cpu to query
+
+    Returns:
+        bool: True if cpu is online, False otherwise
+
+    """
+
+    online = cpus_online()
+    present = cpus_present()
+    return (cpu in present) and (cpu in online)
+
+
 def read_freqs(cpu):
     """ Reads frequencies from sysfs """
     sys_path = Path(SYS_PATH.format(int(cpu)))
@@ -95,7 +111,7 @@ def read_govs(cpu):
 
 
 def read_available_frequencies(cpu):
-    """ Reads governors from sysfs """
+    """ Reads available frequencies from sysfs """
     sys_path = Path(SYS_PATH.format(int(cpu)))
     try:
         sys_file = sys_path / AVAIL_FREQS

--- a/cpupower_gui/window.py
+++ b/cpupower_gui/window.py
@@ -499,6 +499,7 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
         conf = self.settings[cpu]
         fmin, fmax = conf.freqs_scaled
         gov = conf.governor
+        pref = conf.energy_pref
 
         if not HELPER.isauthorized():
             error_message("You don't have permissions to update cpu settings!", self)
@@ -510,6 +511,8 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
                 if self.is_online(cpu):
                     ret = HELPER.update_cpu_settings(cpu, fmin, fmax)
                     ret += HELPER.update_cpu_governor(cpu, gov)
+                    if self.energy_pref_avail:
+                        ret += HELPER.update_cpu_energy_prefs(cpu, pref)
                     self._update_cpu_foreground(cpu, False)
         else:
             # Update only the cpus whose settings were changed
@@ -521,6 +524,7 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
                 if cpu_online:
                     ret += self.set_cpu_frequencies(cpu)
                     ret += self.set_cpu_governor(cpu)
+                    ret += self.set_cpu_energy_preferences(cpu)
                 self._update_cpu_foreground(cpu, False)
 
         # Update sliders
@@ -665,6 +669,32 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
             return ret
 
         ret = HELPER.update_cpu_governor(cpu, gov)
+
+        return ret
+
+    def set_cpu_energy_preferences(self, cpu):
+        """Sets the energy performance preference for cpu
+
+        Args:
+            cpu: Index of cpu to set
+
+        """
+
+        # Return success if not available
+        if not self.energy_pref_avail:
+            return 0
+
+        ret = -1
+        conf = self.settings.get(cpu)
+        if conf is None:
+            return ret
+
+
+        pref = conf.energy_pref
+        if not pref:
+            return ret
+
+        ret = HELPER.update_cpu_energy_prefs(cpu, pref)
 
         return ret
 

--- a/cpupower_gui/window.ui.in
+++ b/cpupower_gui/window.ui.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 
+<!-- Generated with glade 3.36.0 
 
 Copyright (C) 2017-2020 [RnD]²
 
@@ -46,9 +46,6 @@ yjwork-cn</property>
     <property name="logo_icon_name">org.rnd2.cpupower_gui</property>
     <property name="wrap_license">True</property>
     <property name="license_type">gpl-3-0</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
@@ -69,6 +66,9 @@ yjwork-cn</property>
           <placeholder/>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
   <object class="GtkAccelGroup" id="accelgroup1"/>
@@ -119,71 +119,6 @@ yjwork-cn</property>
       <group name="accelgroup1"/>
     </accel-groups>
     <signal name="destroy" handler="on_window_destroy" swapped="no"/>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="title">CPU frequency settings</property>
-        <property name="subtitle" translatable="yes">Adjust the runtime CPU policies</property>
-        <property name="has_subtitle">False</property>
-        <property name="show_close_button">True</property>
-        <property name="decoration_layout">menu:minimize,close</property>
-        <child>
-          <object class="GtkMenuButton" id="menubutton1">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="relief">none</property>
-            <property name="popover">popovermenu</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">org.rnd2.cpupower_gui</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="apply_btn">
-            <property name="label" translatable="yes">Apply</property>
-            <property name="visible">True</property>
-            <property name="sensitive">False</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Apply changes</property>
-            <signal name="clicked" handler="on_apply_clicked" swapped="no"/>
-            <style>
-              <class name="suggested-action"/>
-            </style>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="refresh">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="refresh_icon">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="stock">gtk-refresh</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -246,8 +181,15 @@ yjwork-cn</property>
               <object class="GtkSpinButton" id="spin_max">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="width_chars">7</property>
+                <property name="caps_lock_warning">False</property>
+                <property name="secondary_icon_tooltip_text" translatable="yes">Maximum allowed CPU frequency</property>
                 <property name="adjustment">adj_max</property>
                 <property name="climb_rate">0.01</property>
+                <property name="digits">2</property>
+                <property name="snap_to_ticks">True</property>
+                <property name="numeric">True</property>
+                <property name="update_policy">if-valid</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
@@ -258,9 +200,15 @@ yjwork-cn</property>
               <object class="GtkSpinButton" id="spin_min">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="width_chars">7</property>
+                <property name="caps_lock_warning">False</property>
+                <property name="secondary_icon_tooltip_text" translatable="yes">Minimum allowed CPU frequency</property>
                 <property name="adjustment">adj_min</property>
                 <property name="climb_rate">0.01</property>
+                <property name="digits">2</property>
                 <property name="snap_to_ticks">True</property>
+                <property name="numeric">True</property>
+                <property name="update_policy">if-valid</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
@@ -503,6 +451,71 @@ yjwork-cn</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="header">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title">CPU frequency settings</property>
+        <property name="subtitle" translatable="yes">Adjust the runtime CPU policies</property>
+        <property name="has_subtitle">False</property>
+        <property name="show_close_button">True</property>
+        <property name="decoration_layout">menu:minimize,close</property>
+        <child>
+          <object class="GtkMenuButton" id="menubutton1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="relief">none</property>
+            <property name="popover">popovermenu</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">org.rnd2.cpupower_gui</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="apply_btn">
+            <property name="label" translatable="yes">Apply</property>
+            <property name="visible">True</property>
+            <property name="sensitive">False</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Apply changes</property>
+            <signal name="clicked" handler="on_apply_clicked" swapped="no"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="refresh">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="always_show_image">True</property>
+            <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="refresh_icon">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="stock">gtk-refresh</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
             <property name="position">2</property>
           </packing>
         </child>

--- a/cpupower_gui/window.ui.in
+++ b/cpupower_gui/window.ui.in
@@ -118,7 +118,7 @@ yjwork-cn</property>
     <accel-groups>
       <group name="accelgroup1"/>
     </accel-groups>
-    <signal name="destroy" handler="on_window_destroy" swapped="no"/>
+    <signal name="destroy" handler="quit" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -128,8 +128,6 @@ yjwork-cn</property>
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">8</property>
-            <property name="margin_right">8</property>
             <property name="row_spacing">10</property>
             <property name="column_homogeneous">True</property>
             <child>
@@ -164,8 +162,8 @@ yjwork-cn</property>
               <object class="GtkScale" id="max_sl">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="margin_left">4</property>
-                <property name="margin_right">4</property>
+                <property name="margin_start">2</property>
+                <property name="margin_end">2</property>
                 <property name="adjustment">adj_max</property>
                 <property name="round_digits">0</property>
                 <property name="digits">0</property>
@@ -219,8 +217,8 @@ yjwork-cn</property>
               <object class="GtkScale" id="min_sl">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="margin_left">4</property>
-                <property name="margin_right">4</property>
+                <property name="margin_start">2</property>
+                <property name="margin_end">2</property>
                 <property name="adjustment">adj_min</property>
                 <property name="fill_level">100000</property>
                 <property name="round_digits">0</property>
@@ -347,18 +345,47 @@ yjwork-cn</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
+              <object class="GtkBox" id="pstate_prefs">
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="energy_perf_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Energy profile:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="energy_pref_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <signal name="changed" handler="on_energy_pref_box_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">4</property>
+                <property name="width">2</property>
+              </packing>
             </child>
             <child>
               <placeholder/>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">False</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="padding">5</property>
             <property name="position">1</property>
           </packing>
@@ -510,7 +537,7 @@ yjwork-cn</property>
               <object class="GtkImage" id="refresh_icon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="stock">gtk-refresh</property>
+                <property name="icon_name">view-refresh</property>
               </object>
             </child>
           </object>


### PR DESCRIPTION
Add utilities to read and write to `energy_performance_preferences` file if available.
This only works on Intel systems with the `intel_pstate` driver.

The available energy preferences may differ from system to system but usually are:
- default
- performance
- balance_performance
- balance_power
- power 

They represent different energy vs performance hints and should be self-explanatory, except that default represents whatever hint value was set by the platform firmware. 

After some testing, it seems that changing the governor of the CPU automatically changes the energy preference.
For `powersave` it defaulted to `balance_power` and for `performance` to `performance`.

If the energy profile is explicitly set, changing the governor will not set the profile back.
To switch to an "automatic" preference, that changes with the governor, set the value back to default.

![2020-10-14-013714](https://user-images.githubusercontent.com/16070176/95930201-ccbf4800-0dbd-11eb-82c3-720a74c4b2d1.png)


