### PR TITLE
Fix issues systemd user service at login

### DIFF
--- a/data/services/cpupower-gui-user.service.in
+++ b/data/services/cpupower-gui-user.service.in
@@ -1,9 +1,10 @@
 [Unit]
 Description=Apply cpupower-gui config at user login
+After=default.target
 
 [Service]
 Type=oneshot
 ExecStart=@bindir@/cpupower-gui config
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target


### PR DESCRIPTION
This PR to fix the issue systemd user service doesn't start at login.
And you may need to update the README.md.

``` patch
diff --git a/data/services/cpupower-gui-user.service.in b/data/services/cpupower-gui-user.service.in
index 4305884..54bcecf 100644
--- a/data/services/cpupower-gui-user.service.in
+++ b/data/services/cpupower-gui-user.service.in
@@ -1,9 +1,10 @@
 [Unit]
 Description=Apply cpupower-gui config at user login
+After=default.target
 
 [Service]
 Type=oneshot
 ExecStart=@bindir@/cpupower-gui config
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target
```

Issues Description:
Recently the user service is not working at login.

``` shell
> systemctl --user status cpupower-gui-user.service
* cpupower-gui-user.service - Apply cpupower-gui config at user login
Loaded: loaded (/usr/lib/systemd/user/cpupower-gui-user.service; enabled; vendor preset: enabled)
Active: inactive (dead)
```

The following are my test output after apply this patch:

``` shell
Arch Linux 5.14.0-rc5-5-custom (tty2)
arch login: arch
Last login: Thu Aug 12 13:20:22 on tty2
> systemctl --user status cpupower-gui-user.service
* cpupower-gui-user.service - Apply cpupower-gui config at user login
Loaded: loaded (/usr/lib/systemd/user/cpupower-gui-user.service; enabled; vendor preset: enabled)
Active: inactive (dead) since Thu 2021-08-12 13:31:04 CST; 12s ago
Process: 400 ExecStart=/usr/bin/cpupower-gui config (code=exited, status=0/SUCCESS)
Main PID: 400 (code=exited, status=0/SUCCESS)
CPU: 145ms
Aug 12 13:31:03 arch systemd[390]: Starting Apply cpupower-gui config at user login...
Aug 12 13:31:04 arch systemd[390]: Finished Apply cpupower-gui config at user login.
> systemctl status cpupower-gui.service
* cpupower-gui.service - Apply cpupower-gui config at boot
Loaded: loaded (/usr/lib/systemd/system/cpupower-gui.service; enabled; vendor preset: disabled)
Active: inactive (dead) since Thu 2021-08-12 13:30:31 CST; 52s ago
Docs: https://github.com/vagnum08/cpupower-gui
man:cpupower-gui(1)
Process: 288 ExecStart=/usr/bin/cpupower-gui config (code=exited, status=0/SUCCESS)
Main PID: 288 (code=exited, status=0/SUCCESS)
CPU: 196ms
Aug 12 13:30:16 arch systemd[1]: Starting Apply cpupower-gui config at boot...
Aug 12 13:30:31 arch cpupower-gui[288]: Applying configuration...
Aug 12 13:30:31 arch cpupower-gui[288]: Setting CPU: 0
Aug 12 13:30:31 arch cpupower-gui[288]:     Minimum Frequency: 1203.0 MHz, Maximum Frequency: 3203.0 MHz
Aug 12 13:30:31 arch cpupower-gui[288]:     Governor: Schedutil, Online: True
Aug 12 13:30:31 arch cpupower-gui[288]: Setting CPU: 1
Aug 12 13:30:31 arch cpupower-gui[288]:     Minimum Frequency: 1203.0 MHz, Maximum Frequency: 3203.0 MHz
Aug 12 13:30:31 arch cpupower-gui[288]:     Governor: Schedutil, Online: True
Aug 12 13:30:31 arch systemd[1]: cpupower-gui.service: Deactivated successfully.
Aug 12 13:30:31 arch systemd[1]: Finished Apply cpupower-gui config at boot.
> cat .config/cpupower_gui/00-cpg.conf
[Profile]
profile = Performance
[GUI]
allcpus_default = True
tick_marks_enabled = True
frequency_ticks = True
energy_pref_per_cpu = False
> cat /sys/devices/system/cpu/cpufreq/policy*/scaling_governor
performance
performance
> sudo cat /dev/vcs2 >screenshot
```