### PR TITLE
Add translated Chinese manual page

### DIFF
--- a/cpupower_gui/meson.build
+++ b/cpupower_gui/meson.build
@@ -3,7 +3,7 @@ gnome = import('gnome')
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(prefix, get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)

--- a/data/man/cpupower-gui.1
+++ b/data/man/cpupower-gui.1
@@ -60,7 +60,7 @@ cpupower(1), cpupower-set(1), cpupower-info(1), cpupower-idle(1), cpupower-frequ
 .SH AUTHORS
 Evangelos Rigas <erigas@rnd2.org>
 .br
-Chinese translation written by yjwork-cn
+Chinese translation first written by yjwork-cn and then supdrewin
 .br
 Dutch translation written by Heimen Stoffels <vistausss@outlook.com>
 .br

--- a/data/man/cpupower-gui.zh_CN.1
+++ b/data/man/cpupower-gui.zh_CN.1
@@ -1,0 +1,66 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2019 Evangelos Rigas <e.rigas@cranfield.ac.uk>,
+.\"
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH CPUPOWER-GUI 1 "September 20 2019"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH 名称
+cpupower-gui \- 设置 CPU 的调速器和频率调节范围
+.SH 概述
+.B cpupower-gui
+
+.SH 描述
+本手册用于简要说明 \fBcpupower-gui\fP 命令.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+.\" respectively.
+\fBcpupower-gui\fP 是一个用来改变 CPU 频率的图形化工具。
+.br
+该实用程序可以分别设置 CPU 每个核心的工作频率。 除此之外， 也可以更改 CPU 的调速器。 该程序可以检测到脱机核心并且仅显示可用的核心。 此外， 不支持频率调节的核心将不会被显示。 此程序还提供一个可以同时对所有核心应用相同设置的选项。
+.br
+要应用设置， 用户必须是 \fI本地用户\fP 并且处于 \fI活动状态\fP， 同时要在 \fBsudo\fP 组中。 不在此组中的本地活动用户必须以管理员身份进行身份验证才能应用设置。
+.br
+
+\fIcpupower-gui\fP 程序可以使用 \fB/etc/cpupower_gui.conf\fP 中的配置文件进行配置。 储存在 \fB/etc/cpupower_gui.d/\fP 中的配置文件优先于主配置文件。 程序按照字典顺序读取文件， 后读取的配置文件覆盖先读取的配置文件。
+.br
+除了主要配置外， 用户还可以将自定义配置文件保存在 \fB~/.config/cpupower_gui/\fP 下。 从这个位置读取的配置文件将覆盖原有系统配置文件。
+.br
+
+自定义频率设置将保存到 \fI*.profile\fP 后缀的文件中， 以让用户可以使用它们快速应用自己的偏好设置。 这些配置文件是简单的文本文件， 其中第一行包含配置文件的名字， 文件的其余部分以类表格式包含 CPU 设置。 一个样例在安装时预放在 \fB/etc/cpupower_gui.d/my_profile.profile.ex\fP 中。
+.br
+
+在一些平台上， 此程序可以用来改变能源性能优先级。 这项功能在使用 \fIintel_pstate\fP 这一驱动的 Intel 系统上可用。
+.br
+
+.SH 亦见
+cpupower(1), cpupower-set(1), cpupower-info(1), cpupower-idle(1), cpupower-frequency-set(1), cpupower-frequency-info(1), cpupower-monitor(1), powertop(1)
+.br
+
+.SH 作者
+Evangelos Rigas <erigas@rnd2.org>
+.br
+Chinese translation first written by yjwork-cn and then supdrewin
+.br
+Dutch translation written by Heimen Stoffels <vistausss@outlook.com>
+.br
+Hungarian translation written by Barcza Károly <kbarcza@blackpanther.hu>
+.br
+Italian translation written by Albano Battistella
+.br
+Indonesian translation written by Andika Triwidada <atriwidada@src.gnome.org>
+.br
+Brazilian Portuguese translation written by Flávio Costa <guda.flavio@gmail.com>

--- a/data/meson.build
+++ b/data/meson.build
@@ -69,6 +69,7 @@ install_data('scaling-governors.conf', install_dir: pkgdatadir)
 
 # Manual
 install_man('man/cpupower-gui.1')
+install_man('man/cpupower-gui.zh_CN.1', locale: 'zh_CN')
 
 subdir('services')
 subdir('polkit')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('cpupower-gui',
   version: '1.0.0',
-  meson_version: '>= 0.50.0',
+  meson_version: '>= 0.58.0',
   default_options: ['warning_level=2',
     'systemddir=/usr/lib/systemd',
     'pkla=false',


### PR DESCRIPTION
<details open><summary>Add myself to the list</summary>

``` patch
diff --git a/data/man/cpupower-gui.1 b/data/man/cpupower-gui.1
index 79f61be..d975f82 100644
--- a/data/man/cpupower-gui.1
+++ b/data/man/cpupower-gui.1
@@ -60,7 +60,7 @@ cpupower(1), cpupower-set(1), cpupower-info(1), cpupower-idle(1), cpupower-frequ
 .SH AUTHORS
 Evangelos Rigas <erigas@rnd2.org>
 .br
-Chinese translation written by yjwork-cn
+Chinese translation first written by yjwork-cn and then supdrewin
 .br
 Dutch translation written by Heimen Stoffels <vistausss@outlook.com>
 .br
```
</details><details><summary>Add translated manual page, this patch is too long to show</summary>

``` patch
diff --git a/data/man/cpupower-gui.zh_CN.1 b/data/man/cpupower-gui.zh_CN.1
new file mode 100644
index 0000000..bbc0e1c
--- /dev/null
+++ b/data/man/cpupower-gui.zh_CN.1
@@ -0,0 +1,66 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2019 Evangelos Rigas <e.rigas@cranfield.ac.uk>,
+.\"
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH CPUPOWER-GUI 1 "September 20 2019"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH 名称
+cpupower-gui \- 设置 CPU 的调速器和频率调节范围
+.SH 概述
+.B cpupower-gui
+
+.SH 描述
+本手册用于简要说明 \fBcpupower-gui\fP 命令.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+.\" respectively.
+\fBcpupower-gui\fP 是一个用来改变 CPU 频率的图形化工具。
+.br
+该实用程序可以分别设置 CPU 每个核心的工作频率。 除此之外， 也可以更改 CPU 的调速器。 该程序可以检测到脱机核心并且仅显示可用的核心。 此外， 不支持频率调节的核心将不会被显示。 此程序还提供一个可以同时对所有核心应用相同设置的选项。
+.br
+要应用设置， 用户必须是 \fI本地用户\fP 并且处于 \fI活动状态\fP， 同时要在 \fBsudo\fP 组中。 不在此组中的本地活动用户必须以管理员身份进行身份验证才能应用设置。
+.br
+
+\fIcpupower-gui\fP 程序可以使用 \fB/etc/cpupower_gui.conf\fP 中的配置文件进行配置。 储存在 \fB/etc/cpupower_gui.d/\fP 中的配置文件优先于主配置文件。 程序按照字典顺序读取文件， 后读取的配置文件覆盖先读取的配置文件。
+.br
+除了主要配置外， 用户还可以将自定义配置文件保存在 \fB~/.config/cpupower_gui/\fP 下。 从这个位置读取的配置文件将覆盖原有系统配置文件。
+.br
+
+自定义频率设置将保存到 \fI*.profile\fP 后缀的文件中， 以让用户可以使用它们快速应用自己的偏好设置。 这些配置文件是简单的文本文件， 其中第一行包含配置文件的名字， 文件的其余部分以类表格式包含 CPU 设置。 一个样例在安装时预放在 \fB/etc/cpupower_gui.d/my_profile.profile.ex\fP 中。
+.br
+
+在一些平台上， 此程序可以用来改变能源性能优先级。 这项功能在使用 \fIintel_pstate\fP 这一驱动的 Intel 系统上可用。
+.br
+
+.SH 亦见
+cpupower(1), cpupower-set(1), cpupower-info(1), cpupower-idle(1), cpupower-frequency-set(1), cpupower-frequency-info(1), cpupower-monitor(1), powertop(1)
+.br
+
+.SH 作者
+Evangelos Rigas <erigas@rnd2.org>
+.br
+Chinese translation first written by yjwork-cn and then supdrewin
+.br
+Dutch translation written by Heimen Stoffels <vistausss@outlook.com>
+.br
+Hungarian translation written by Barcza Károly <kbarcza@blackpanther.hu>
+.br
+Italian translation written by Albano Battistella
+.br
+Indonesian translation written by Andika Triwidada <atriwidada@src.gnome.org>
+.br
+Brazilian Portuguese translation written by Flávio Costa <guda.flavio@gmail.com>
```
</details><details open><summary>Install added manual page</summary>

``` patch
diff --git a/data/meson.build b/data/meson.build
index d51790d..a2be472 100644
--- a/data/meson.build
+++ b/data/meson.build
@@ -69,6 +69,7 @@ install_data('scaling-governors.conf', install_dir: pkgdatadir)
 
 # Manual
 install_man('man/cpupower-gui.1')
+install_man('man/cpupower-gui.zh_CN.1', locale: 'zh_CN')
 
 subdir('services')
 subdir('polkit')
```
</details><details open><summary><a href="https://mesonbuild.com/Reference-manual.html#install_man">Required by install_man() with 'locale' keyword</a></summary>

``` patch
diff --git a/meson.build b/meson.build
index 8fd595e..d1e4f57 100644
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('cpupower-gui',
   version: '1.0.0',
-  meson_version: '>= 0.50.0',
+  meson_version: '>= 0.58.0',
   default_options: ['warning_level=2',
     'systemddir=/usr/lib/systemd',
     'pkla=false',
```
</details><details open><summary><a href="https://mesonbuild.com/Reference-manual.html#external-program-object">Hibernate deprecated warning for the changed meson version</a></summary>

``` patch
diff --git a/cpupower_gui/meson.build b/cpupower_gui/meson.build
index 0607200..188850c 100644
--- a/cpupower_gui/meson.build
+++ b/cpupower_gui/meson.build
@@ -3,7 +3,7 @@ gnome = import('gnome')
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(prefix, get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)
```
</details>