### PR TITLE
Fix Desktop Actions can't switch modes

### DIFF
--- a/data/org.rnd2.cpupower_gui.desktop.in.in
+++ b/data/org.rnd2.cpupower_gui.desktop.in.in
@@ -15,8 +15,8 @@ Actions=Performance;Balanced;
 
 [Desktop Action Performance]
 Name=Switch to Performance profile
-Exec=gapplication launch org.rnd2.cpupower_gui Performance
+Exec=gapplication action org.rnd2.cpupower_gui Performance
 
 [Desktop Action Balanced]
 Name=Switch to Balanced profile
-Exec=gapplication launch org.rnd2.cpupower_gui Balanced
+Exec=gapplication action org.rnd2.cpupower_gui Balanced


### PR DESCRIPTION
### This PR to fix Desktop Actions can't switch modes
Restore the issue happened:
``` shell
> gapplication launch org.rnd2.cpupower_gui Balanced
error sending Open message to application: GDBus.Error:org.freedesktop.DBus.Error.NotSupported:
Application does not open files
> gapplication launch org.rnd2.cpupower_gui Performance
error sending Open message to application: GDBus.Error:org.freedesktop.DBus.Error.NotSupported:
Application does not open files
```
When I looked at the man page of `gapplication`, I found that the extra option for `launch` is ***files***.
The correct way to activate the actions seems to be using `action` instead.
``` patch
diff --git a/data/org.rnd2.cpupower_gui.desktop.in.in b/data/org.rnd2.cpupower_gui.desktop.in.in
index 4dca09b..2e01156 100644
--- a/data/org.rnd2.cpupower_gui.desktop.in.in
+++ b/data/org.rnd2.cpupower_gui.desktop.in.in
@@ -15,8 +15,8 @@ Actions=Performance;Balanced;

 [Desktop Action Performance]
 Name=Switch to Performance profile
-Exec=gapplication launch org.rnd2.cpupower_gui Performance
+Exec=gapplication action org.rnd2.cpupower_gui Performance

 [Desktop Action Balanced]
 Name=Switch to Balanced profile
-Exec=gapplication launch org.rnd2.cpupower_gui Balanced
+Exec=gapplication action org.rnd2.cpupower_gui Balanced
```