### PR TITLE
[window] Minimise to tray icon if supported

### DIFF
--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -542,6 +542,8 @@ class CpuSettings:
 
     @property
     def govid(self):
+        if self.governor == "OFFLINE":
+            return None
         return self._governors.index(self.governor)
 
     @property

--- a/cpupower_gui/utils.py
+++ b/cpupower_gui/utils.py
@@ -145,16 +145,17 @@ def read_available_frequencies(cpu):
 def read_governor(cpu):
     """Reads governor from sysfs"""
     sys_path = Path(SYS_PATH.format(int(cpu)))
-    if is_online(cpu):
-        try:
-            sys_file = sys_path / GOVERNOR
-            governor = sys_file.read_text().strip()
-        except OSError:
-            governor = "ERROR"
-        finally:
-            return governor
-    else:
-        return "offline"
+
+    if not is_online(cpu):
+        return "OFFLINE"
+
+    try:
+        sys_file = sys_path / GOVERNOR
+        governor = sys_file.read_text().strip()
+    except OSError:
+        governor = "ERROR"
+    finally:
+        return governor
 
 
 def read_available_energy_prefs(cpu):

--- a/cpupower_gui/window.py
+++ b/cpupower_gui/window.py
@@ -28,6 +28,12 @@ except (ValueError, ImportError):
 
 from gi.repository import Gio, GLib, GObject, Gtk
 
+try:
+    gi.require_version("AyatanaAppIndicator3", "0.1")
+    HasTray = True
+except ValueError:
+    HasTray = False
+
 from .config import CpuPowerConfig, CpuSettings
 from .utils import read_available_frequencies, read_current_freq
 
@@ -47,9 +53,9 @@ ERRORS = {
     -25: _("Setting frequencies and energy preferences failed."),
 }
 
+
 # Abstractions for Gio List store
 class CpuCore(GObject.GObject):
-
     name = GObject.Property(type=str)
 
     def __init__(self, name):
@@ -58,7 +64,6 @@ class CpuCore(GObject.GObject):
 
 
 class EnergyPref(GObject.GObject):
-
     prefid = GObject.Property(type=int)
     name = GObject.Property(type=str)
 
@@ -69,7 +74,6 @@ class EnergyPref(GObject.GObject):
 
 
 class Governor(GObject.GObject):
-
     govid = GObject.Property(type=int)
     name = GObject.Property(type=str)
 
@@ -80,7 +84,6 @@ class Governor(GObject.GObject):
 
 
 class Profile(GObject.GObject):
-
     name = GObject.Property(type=str)
 
     def __init__(self, profile):
@@ -156,6 +159,8 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
         self.squeezer.connect(
             "notify::visible-child", self.on_headerbar_squeezer_notify
         )
+        if HasTray:
+            self.connect("delete-event", self.to_tray)
         # Read configuration
         self.conf = CpuPowerConfig()
         # Get GUI config and profiles
@@ -333,8 +338,13 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
 
     def quit(self, *args):
         """Quit"""
-        HELPER.quit()
+        print("Quiting...")
+        # HELPER.quit()
         exit(0)
+
+    def to_tray(self, *args):
+        self.hide()
+        return True
 
     def _reset_energy_conf(self, cpu):
         if cpu == -1:

--- a/cpupower_gui/window.py
+++ b/cpupower_gui/window.py
@@ -556,7 +556,7 @@ class CpupowerGuiWindow(Gtk.ApplicationWindow):
             self.gov_box.bind_name_model(gov_store, lambda x: x.name)
             self.gov_box.set_selected_index(governor)
             self.gov_box.set_sensitive(True)
-        else:
+        else:  # CPU OFFLINE
             self.gov_box.set_sensitive(False)
 
     def _update_current_freq(self):


### PR DESCRIPTION
Breaking change: `Requires libayatana-appindicator-3-1`

If `appindicator` is available minimise to tray instead of closing the application.

The tray menu includes user-generated profiles.

Fixes: #84