### PR TITLE
Fixed Python 3.14 compatibility issue

### DIFF
--- a/cpupower_gui/cpupower-gui.in
+++ b/cpupower_gui/cpupower-gui.in
@@ -266,7 +266,7 @@ profile_sub.set_defaults(func=set_profile)
 # Config commands
 config_sub = subparsers.add_parser("config", aliases=["co"])
 config_sub.add_argument(
-    "apply", action="store_true", help="apply cpupower configuration",
+    "-a", "--apply", action="store_true", help="apply cpupower configuration",
 )
 config_sub.set_defaults(func=set_config)
 

--- a/data/org.rnd2.cpupower_gui.appdata.xml.in
+++ b/data/org.rnd2.cpupower_gui.appdata.xml.in
@@ -37,6 +37,11 @@
     <developer_name>Evangelos Rigas</developer_name>
     <content_rating type="oars-1.1"/>
     <releases>
+     <release version="1.0.1" date="2026-01-12">
+      <description>
+        <p>Fix Python 3.14 compatibility issue with argparse</p>
+	    </description>
+	   </release>
      <release version="1.0.0" date="2020-11-6">
       <description>
         <p>Add Italian translation</p>

--- a/data/services/cpupower-gui.service.in
+++ b/data/services/cpupower-gui.service.in
@@ -4,7 +4,7 @@ Documentation=https://github.com/vagnum08/cpupower-gui man:cpupower-gui(1)
 
 [Service]
 Type=oneshot
-ExecStart=@bindir@/cpupower-gui config
+ExecStart=@bindir@/cpupower-gui config -a
 
 [Install]
 WantedBy=multi-user.target

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cpupower-gui',
-  version: '1.0.0',
+  version: '1.0.1',
   meson_version: '>= 0.58.0',
   default_options: ['warning_level=2',
     'systemddir=/usr/lib/systemd',


### PR DESCRIPTION
Pull Request that fixes Python 3.14 `argparse` compatibility issue: [https://github.com/vagnum08/cpupower-gui/issues/138](138)