### PR TITLE
Fix loading profile names

### DIFF
--- a/cpupower_gui/config.py
+++ b/cpupower_gui/config.py
@@ -246,7 +246,8 @@ class Profile:
         text = self.file.read_text().splitlines()
         # read name
         if "name:" in text[0]:
-            self.name = split(text[0])[-1]
+            name = text[0].split("# name:")[-1]
+            self.name = name.strip().strip('"').strip()
         else:
             self.name = self.file.name
 


### PR DESCRIPTION
Fix the logic of reading profile names from .profile files. It now handles names with spaces and quotation marks.

Closes #129